### PR TITLE
Many game additions

### DIFF
--- a/Winapp2.ini
+++ b/Winapp2.ini
@@ -3086,6 +3086,12 @@ Default=False
 FileKey1=%LocalAppData%\AA2DeployClient|debug*.*
 FileKey2=%ProgramFiles%\USArmy\America's Army 2|*.log|RECURSE
 
+[AMID EVIL *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\673130
+Default=False
+FileKey1=%LocalAppData%\AmidEvil\Saved\Logs|*.*
+
 [Amnesia: The Dark Descent *]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\57300
@@ -3534,6 +3540,12 @@ Detect3=HKCU\Software\Ashampoo\Ashampoo Snap 9
 Detect4=HKCU\Software\Ashampoo\Ashampoo Snap 10
 Default=False
 FileKey1=%Pictures%\Ashampoo Snap *\_SNAPDOC|*.*|RECURSE
+
+[Ashes of the Sinularity *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\507490
+Default=False
+FileKey1=%LocalAppData%\Ashes of the Singularity\Stardock\Tachyon|*.txt
 
 [Ashley Jones and the Heart of Egypt *]
 Section=Games
@@ -4437,7 +4449,8 @@ FileKey1=%ProgramFiles%\BOINC|stdout*.*;stderr*.*
 Section=Games
 Detect1=HKCU\Software\Valve\Steam\Apps\8980
 Detect2=HKCU\Software\Valve\Steam\Apps\49520
-Detect3=HKLM\Software\Borderlands
+Detect3=HKCU\Software\Valve\Steam\Apps\261640
+Detect4=HKCU\Software\Valve\Steam\Apps\729040
 Default=False
 FileKey1=%Documents%\My Games\Borderlands*\WillowGame\Logs|*.*
 
@@ -5734,12 +5747,33 @@ Default=False
 FileKey1=%LocalAppData%\CrypTool2\Temp|*.*|REMOVESELF
 RegKey1=HKCU\Software\CrypTool2.0|recentFileList
 
-[Crysis 3 *]
+[Crysis *]
 Section=Games
-Detect=HKLM\Software\Crytek\Crysis 3
+Detect1=HKLM\Software\Valve\Steam\Apps\17300
+Detect2=HKLM\Software\Valve\Steam\Apps\17330
+Detect3=HKLM\Software\Valve\Steam\Apps\108800
+Detect4=HKLM\Software\WOW6432Node\Origin Games\71503
+Detect5=HKLM\Software\WOW6432Node\Origin Games\1003295
+Detect6=HKLM\Software\WOW6432Node\Origin Games\1003302
+Detect7=HKLM\Software\WOW6432Node\Origin Games\1003310
 Default=False
-FileKey1=%ProgramFiles%\Origin Games\Crysis 3\LogBackups|*.*
-FileKey2=%UserProfile%\Saved Games\Crysis 3|*.Log.txt
+FileKey1=%ProgramFiles%\Origin Games\Crysis *|*.log
+FileKey2=%ProgramFiles%\Origin Games\Crysis *\LogBackups|*.*
+FileKey3=%ProgramFiles%\Steam\Steamapps\common\Crysis *|*.log
+FileKey4=%ProgramFiles%\Steam\Steamapps\common\Crysis *\LogBackups|*.*
+
+[Crysis Cache *]
+Section=Games
+Detect1=HKLM\Software\Valve\Steam\Apps\17300
+Detect2=HKLM\Software\Valve\Steam\Apps\17330
+Detect3=HKLM\Software\Valve\Steam\Apps\108800
+Detect4=HKLM\Software\WOW6432Node\Origin Games\71503
+Detect5=HKLM\Software\WOW6432Node\Origin Games\1003295
+Detect6=HKLM\Software\WOW6432Node\Origin Games\1003302
+Detect7=HKLM\Software\WOW6432Node\Origin Games\1003310
+Default=False
+FileKey1=%Documents%\My Games\Crysis*\Shaders\Cache|*.*|RECURSE
+FileKey2=%UserProfile%\Saved Games\Crysis*\Shaders\Cache|*.*|RECURSE
 
 [CrystalDiskInfo *]
 LangSecRef=3024
@@ -6097,6 +6131,19 @@ Default=False
 FileKey1=%AppData%\DarkBlood ServiceST|*.txt
 FileKey2=%ProgramFiles%\Steam\SteamApps\Common\Dark Blood\logs|*.*|RECURSE
 
+[Darksiders II Deathinitive Edition Backups *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\388410
+Default=False
+Warning=You won't be able to restore corrupted saves.
+FileKey1=%ProgramFiles%\Steam\steamapps\common\Darksiders II Deathinitive Edition\Debug Saves|*.*
+
+[Darksiders Warmastered Edition *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\462780
+Default=False
+FileKey1=%ProgramFiles%\Steam\steamapps\common\Darksiders Warmastered Edition|*.log
+
 [Darkspore *]
 Section=Games
 DetectFile=%ProgramFiles%\Origin Games\Darkspore
@@ -6161,9 +6208,11 @@ FileKey2=%ProgramFiles%\Steam\SteamApps\Common\DC Universe Online|.downloadInfo.
 
 [Dead Island *]
 Section=Games
-Detect=HKCU\Software\Valve\Steam\Apps\91310
+Detect1=HKCU\Software\Valve\Steam\Apps\91310
+Detect2=HKCU\Software\Valve\Steam\Apps\383150
+Detect3=HKCU\Software\Valve\Steam\Apps\383180
 Default=False
-FileKey1=%Documents%\DeadIsland\out\logs|*.*
+FileKey1=%Documents%\DeadIsland*\out\logs|*.*
 
 [Dear Esther *]
 Section=Games
@@ -6671,7 +6720,7 @@ Default=False
 FileKey1=%SystemDrive%\Dooble\*\.dooble|cookies.db;favicons.fb;history.db
 FileKey2=%SystemDrive%\Dooble\*\.dooble\Cache|*.*|REMOVESELF
 
-[DOOM *]
+[DOOM 2016 *]
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\379720
 Default=False
@@ -6955,6 +7004,12 @@ Default=False
 FileKey1=%AppData%\DigitalVolcano\DuplicateCleaner|*.data
 FileKey2=%Documents%|Duplicate Cleaner log.txt
 
+[DUSK *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\519860
+Default=False
+FileKey1=%LocalLowAppData%\David Szymanski\Dusk|output_log.txt
+
 [DVBDream *]
 LangSecRef=3024
 Detect=HKLM\Software\DVBDream
@@ -7090,6 +7145,12 @@ FileKey6=%LocalAppData%\DxO*\DxO*\*Cache|*.*|RECURSE
 FileKey7=%LocalAppData%\DxO*\DxO*\CrashReports|*.*|RECURSE
 FileKey8=%LocalAppData%\DxO*\DxO*\Logs|*.*
 FileKey9=%LocalAppData%\DxO*\Logs|*.*
+
+[Dying Light *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\239140
+Default=False
+FileKey1=%Documents%\Dying Light\out\logs|*.*
 
 [Dyn Updater *]
 LangSecRef=3022
@@ -8746,6 +8807,18 @@ Detect=HKCU\Software\KC Softwares\HDDExpert
 Default=False
 FileKey1=%AppData%\KC Softwares\HDDExpert|*.log
 
+[Hearthstone *]
+Section=Games
+Detect=HKCU\Software\Blizzard Entertainment\Hearthstone
+Default=False
+FileKey1=%LocalAppData%\Blizzard\Hearthstone\Logs|*.*
+
+[Hearthstone Cache *]
+Section=Games
+Detect=HKCU\Software\Blizzard Entertainment\Hearthstone
+Default=False
+FileKey1=%LocalAppData%\Blizzard\Hearthstone\Cache|*.*|RECURSE
+
 [Hedgewars VideoTemp *]
 Section=Games
 Detect=HKLM\Software\Hedgewars
@@ -8771,6 +8844,18 @@ Section=Games
 Detect=HKCU\Software\Heroes of Newerth
 Default=False
 FileKey1=%Documents%\Heroes of Newerth\game|console.log
+
+[Heroes of the Storm *]
+Section=Games
+Detect=HKLM\Software\WOW6432Node\Blizzard Entertainment\Heroes of the Storm
+Default=False
+FileKey1=%Documents%\Heroes of the Storm\GameLogs|*.*
+
+[Heroes of the Storm Cache *]
+Section=Games
+Detect=HKLM\Software\WOW6432Node\Blizzard Entertainment\Heroes of the Storm
+Default=False
+FileKey1=%LocalAppData%\Blizzard Entertainment\Heroes of the Storm\BrowserCookies|*.*|RECURSE
 
 [Hex Chat *]
 LangSecRef=3024
@@ -8819,6 +8904,27 @@ LangSecRef=3023
 DetectFile=%ProgramFiles%\HomeCinema
 Default=False
 FileKey1=%ProgramFiles%\HomeCinema\PowerProducer\Template\Cyberlink\frame|*tmp
+
+[Homeworld: Deserts of Kharak Backups *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\281610
+Default=False
+Warning=You will not be able to restore corrupted saves.
+FileKey1=%ProgramFiles%\Steam\steamapps\common\Deserts of Kharak\out\backup|*.*|RECURSE
+
+[Homeworld Remastered Collection *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\244160
+Default=False
+FileKey1=%ProgramFiles%\Steam\steamapps\common\Homeworld\Homeworld2Classic\Bin\LOGFILES|*.*
+FileKey2=%ProgramFiles%\Steam\steamapps\common\Homeworld\HomeworldRM\Bin\LOGFILES|*.*
+
+[Homeworld Remastered Collection Cache *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\244160
+Default=False
+FileKey1=%ProgramFiles%\Steam\steamapps\common\Homeworld\Homeworld2Classic\Bin\CACHE|*.*|RECURSE
+FileKey2=%ProgramFiles%\Steam\steamapps\common\Homeworld\HomeworldRM\Bin\CACHE|*.*|RECURSE
 
 [Honeyview Bookmarks *]
 LangSecRef=3023
@@ -10229,6 +10335,12 @@ DetectFile=%AppData%\MysteryStudio\Lavender
 Default=False
 FileKey1=%AppData%\MysteryStudio\Lavender|*.log
 
+[Layers of Fear Cache *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\391720
+Default=False
+FileKey1=%AppData%\Aspyr Media\GameGuide\Cache|*.*|RECURSE
+
 [League of Legends *]
 Section=Games
 Detect1=HKCU\Software\Bugsplat\lol_beta_riotgames_com
@@ -10742,9 +10854,11 @@ FileKey2=%ProgramFiles%\Mass Downloader\Index|*.*|RECURSE
 
 [Mass Effect *]
 Section=Games
-Detect1=HKLM\Software\BioWare\Mass Effect
-Detect2=HKLM\Software\BioWare\Mass Effect 2
-Detect3=HKLM\Software\BioWare\Mass Effect 3
+Detect1=HKCU\Software\Valve\Steam\Apps\17460
+Detect2=HKCU\Software\Valve\Steam\Apps\24980
+Detect3=HKLM\Software\WOW6432Node\BioWare\Mass Effect
+Detect4=HKLM\Software\WOW6432Node\BioWare\Mass Effect 2
+Detect5=HKLM\Software\WOW6432Node\BioWare\Mass Effect 3
 Default=False
 FileKey1=%Documents%\BioWare\Mass Effect*\BIOGame\Logs|*.*
 FileKey2=%Documents%\BioWare\Mass Effect*\Logs|*.*
@@ -11278,6 +11392,13 @@ LangSecRef=3021
 Detect=HKCU\Software\mirkes.de\Tiny Hexer
 Default=False
 FileKey1=%AppData%\mirkes.de\Tiny Hexer\*|*.bak
+
+[Mirrors Edge Catalyst Backup *]
+Section=Games
+Detect=HKLM\Software\WOW6432Node\Origin Games\1026480
+Default=False
+Warning=You will not be able to restore old profiles.
+FileKey1=%Documents%\Mirrors Edge Catalyst\settings|PROF_SAVE_backup*
 
 [MiTeC DFM Editor *]
 LangSecRef=3021
@@ -12984,6 +13105,18 @@ FileKey3=%AppData%\obs-studio\crashes|*.*
 FileKey4=%AppData%\obs-studio\logs|*.*
 FileKey5=%AppData%\obs-studio\profiler_data|*.*
 
+[Observer *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\514900
+Default=False
+FileKey1=%LocalAppData%\TheObserver\Saved\Logs|*.*
+
+[Observer Cache *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\514900
+Default=False
+FileKey1=%AppData%\Aspyr Media\Game Guide 3\Cache|*.*|RECURSE
+
 [OcenAudio MRU *]
 LangSecRef=3023
 Detect1=HKCU\Software\OcenAudio
@@ -13269,7 +13402,13 @@ FileKey2=%ProgramFiles%\Osu!|debug-import.txt
 Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\238320
 Default=False
-FileKey1=%Documents%\My Games\Outlast\OLGame\Logs|*.dmp;*.log
+FileKey1=%Documents%\My Games\Outlast\OLGame\Logs|*.*
+
+[Outlast 2 *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\414700
+Default=False
+FileKey1=%Documents%\My Games\Outlast2\OLGame\Logs|*.*
 
 [Outlook 2003 *]
 LangSecRef=3021
@@ -13355,6 +13494,12 @@ DetectFile=%ProgramFiles%\Buka\Pacific Storm
 Default=False
 FileKey1=%ProgramFiles%\Buka\Pacific Storm|*.log|RECURSE
 FileKey2=%ProgramFiles%\Steam\SteamApps\Common\Pacific Storm*|*.log|RECURSE
+
+[Painkiller Hell and Damnation *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\214870
+Default=False
+FileKey1=%Documents%\My Games\Painkiller Hell and Damnation\PKHDGame\Logs|*.*
 
 [Paint 3D *]
 DetectOS=10.0|
@@ -13628,6 +13773,24 @@ Default=False
 RegKey1=HKCU\Software\Pelle Orinius\PellesC\Recent File List
 RegKey2=HKCU\Software\Pelle Orinius\PellesC\Recent Project List
 RegKey3=HKCU\Software\Pelle Orinius\PellesC\Recent Search List
+
+[Penumbra Black Plague *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\22120
+Default=False
+FileKey1=%Documents%\Penumbra\Black Plague|*.log
+
+[Penumbra Overture *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\22180
+Default=False
+FileKey1=%Documents%\Penumbra\Requiem|*.log
+
+[Penumbra Requiem *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\22140
+Default=False
+FileKey1=%Documents%\Penumbra Overture\Episode1|*.log
 
 [People *]
 DetectOS=10.0|
@@ -14815,6 +14978,12 @@ Detect2=HKCU\Software\Microsoft\Microsoft Games\RiseofNationsExpansion
 Default=False
 FileKey1=%AppData%\Microsoft Games\Rise of Nations\Logs|*.*
 
+[Rise of the Tomb Raider *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\391220
+Default=False
+FileKey1=%Documents%\Rise of the Tomb Raider|*.log
+
 [Rkill *]
 LangSecRef=3024
 DetectFile1=%UserProfile%\Desktop\Rkill
@@ -15190,17 +15359,20 @@ Default=False
 FileKey1=%CommonAppData%\Sendori|*.log
 
 [Serious Sam *]
-Section=Games
-Detect1=HKCU\Software\Valve\Steam\Apps\41014
-Detect2=HKCU\Software\Valve\Steam\Apps\41070
-Detect3=HKCU\Software\Valve\Steam\Apps\564310
+Detect1=HKCU\Software\Valve\Steam\Apps\41000
+Detect2=HKCU\Software\Valve\Steam\Apps\41010
+Detect3=HKCU\Software\Valve\Steam\Apps\41014
+Detect4=HKCU\Software\Valve\Steam\Apps\41050
+Detect5=HKCU\Software\Valve\Steam\Apps\41060
+Detect6=HKCU\Software\Valve\Steam\Apps\41070
+Detect7=HKCU\Software\Valve\Steam\Apps\204340
+Detect8=HKCU\Software\Valve\Steam\Apps\227780
+Detect9=HKCU\Software\Valve\Steam\Apps\564310
 DetectFile=%ProgramFiles%\Croteam\Serious Sam *
 Default=False
-FileKey1=%ProgramFiles%\Croteam\Serious Sam *|*.log
-FileKey2=%ProgramFiles%\Croteam\Serious Sam *\Temp|*.*
-FileKey3=%ProgramFiles%\Steam\SteamApps\Common\Serious Sam *|*.log
-FileKey4=%ProgramFiles%\Steam\SteamApps\Common\Serious Sam *\Log|*.*|RECURSE
-FileKey5=%ProgramFiles%\Steam\SteamApps\Common\Serious Sam *\Temp|*.*
+FileKey1=%ProgramFiles%\Steam\steamApps\Common\Serious Sam *|*.log
+FileKey2=%ProgramFiles%\Steam\steamApps\Common\Serious Sam *\Log|*.*|RECURSE
+FileKey3=%ProgramFiles%\Steam\steamApps\Common\Serious Sam *\Temp|*.*
 
 [ServeToMe *]
 LangSecRef=3023
@@ -15467,6 +15639,12 @@ Detect=HKCU\Software\Valve\Steam\Apps\202170
 Default=False
 FileKey1=%ProgramFiles%\Steam\Steamapps\common\SleepingDogs|LogBoot.txt;LogShaders.txt
 
+[Slender: The Arrival *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\252330
+Default=False
+FileKey1=%ProgramFiles%\Steam\steamapps\common\Slender - The Arrival\Slender - The Arrival_Data|output_log.txt
+
 [SlimBoat *]
 LangSecRef=3022
 DetectFile=%ProgramFiles%\SlimBoat\SlimBoat.exe
@@ -15713,6 +15891,12 @@ Section=Games
 Detect=HKCU\Software\Valve\Steam\Apps\284990
 Default=False
 FileKey1=%ProgramFiles%\Steam\SteamApps\common\Solarix\UDKGame\Logs|*.*
+
+[SOMA *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\282140
+Default=False
+FileKey1=%Documents%\My Games\Soma\Main|*.log
 
 [Sonata *]
 LangSecRef=3024
@@ -16072,13 +16256,19 @@ FileKey6=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\__Installer|In
 FileKey7=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\logs|*.*
 FileKey8=%ProgramFiles%\Origin Games\Star Wars - The Old Republic\swtor\retailclient\swtor\logs|*.*
 
+[StarCraft *]
+Section=Games
+Detect=HKCU\Software\Blizzard Entertainment\Starcraft
+Default=False
+FileKey1=%AppData%\Blizzard\StarCraft|*Log.txt
+FileKey2=%Documents%\StarCraft\Errors|*.*
+
 [StarCraft II *]
 Section=Games
-Detect=HKLM\Software\Blizzard Entertainment\StarCraft II
+Detect1=HKLM\Software\Blizzard Entertainment\StarCraft II
+Detect2=HKLM\Software\WOW6432Node\Blizzard Entertainment\StarCraft II
 Default=False
-FileKey1=%CommonAppData%\Blizzard Entertainment\Starcraft II\Maps\Cache|*.*|RECURSE
-FileKey2=%Documents%\StarCraft II\*Logs|*.*|RECURSE
-FileKey3=%ProgramFiles%\Starcraft II\Logs|*.*
+FileKey1=%Documents%\StarCraft II\*Logs|*.*|RECURSE
 
 [StarCraft II Editor *]
 Section=Games
@@ -16901,6 +17091,13 @@ Detect2=HKCU\Software\Valve\Steam\Apps\20920
 Default=False
 FileKey1=%LocalAppData%\The Witcher 2\temp|*.*
 FileKey2=%LocalAppData%\The Witcher\logs|*.*
+
+[The Witcher 3 Backups *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\292030
+Default=False
+Warning=You will not be able to restore old settings configurations.
+FileKey1=%Documents%\The Witcher 3|*.bak
 
 [Thinstall Database *]
 LangSecRef=3021
@@ -18220,6 +18417,13 @@ DetectFile=%ProgramFiles%\WeFi
 Default=False
 FileKey1=%CommonAppData%\WeFi\LogFiles|*.*|REMOVESELF
 
+[West of Loathing *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\597220
+Default=False
+FileKey1=%LocalLowAppData%\Asymmetric Software\West of Loathing|*output_log.txt
+FileKey2=%LocalLowAppData%\Asymmetric Software\West of Loathing\Crashes|*.*
+
 [Western Digital Firmware Updater *]
 LangSecRef=3024
 DetectFile=%CommonAppData%\Western Digital
@@ -19162,6 +19366,18 @@ FileKey9=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\LocalState\navigation
 FileKey10=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\LocalState\PlayReady|*.*|RECURSE
 FileKey11=%LocalAppData%\Packages\Microsoft.XboxLIVEGames_*\TempState|*.*|RECURSE
 RegKey1=HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\SystemAppData\Microsoft.XboxLIVEGames_8wekyb3d8bbwe\SearchHistory
+
+[XCOM: Enemy Unknown *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\200510
+Default=False
+FileKey1=%Documents%\My Games\Outlast\OLGame\Logs|*.*
+
+[XCOM 2 *]
+Section=Games
+Detect=HKCU\Software\Valve\Steam\Apps\268500
+Default=False
+FileKey1=%Documents%\My Games\XCOM2\XComGame\Logs|*.*
 
 [Xenocode Sandbox *]
 LangSecRef=3021


### PR DESCRIPTION
Hey everyone.

Well, I had some spare time and figured I would come back to this project. I got a somewhat large update here for you guys. All of them are cleaning rules for various game. Here is the summary of whats new (may not be 100% accurate because I changed some things at last minute).

Modify:

Borderlands

- Removed old Detect 3 as it is uneeded and added support for pre-sequel and GOTY enhanced.

Crysis

- Changed name to Crysis, added support for Crysis 1, Crysis Warhead, and Crysis 2, added support for Origin and Steam installs and cleaning.

DOOM 2016

- Changed name to DOOM 2016, to not be confused with the original DOOM.

Mass Effect

Changed detects to support both Steam and Origin installs.

Outlast

- Changed FileKey 1.

Serious Sam

- Added support for Classic TFE. Classic TSE, Revolution, TFE HD, SS2, and Fusion. Removed FileKey 1 and 2 because they are uneeded.

StarCraft II

- Added Detect2 for 64-bit path, removed FileKey 1 and 3 as no log files existed in those areas anymore with recent updates.

Added:

AMID EVIL

Ashes of the Sinularity

Crysis Cache

Darksiders Warmastered Edition

Darksiders II Deathinitive Edition Backups

Dead Island Definitive Edition

Dead Island Riptide Definitive Edition

DUSK

Dying Light

Hearthstone

Hearthstone Cache

Heroes of the Storm

Heroes of the Storm Cache

Homeworld: Deserts of Kharak Backups

Homeworld Remastered Collection

Homeworld Remastered Collection Cache

Layers of Fear Cache

Mirrors Edge Catalyst

Observer

Observer Cache

Outlast 2

Painkiller Hell and Damnation

Penumbra Black Plague

Penumbra Overture

Penumbra Requiem

Rise of the Tomb Raider

Slender: The Arrival

SOMA

StarCraft

The Witcher 3 Backups

West of Loathing

XCOM: Enemy Unknown

XCOM 2